### PR TITLE
Adds a health check prosessor based on the ping messages sent from th…

### DIFF
--- a/src/ha_mqtt/HAMQTTHealthCheck.cpp
+++ b/src/ha_mqtt/HAMQTTHealthCheck.cpp
@@ -1,0 +1,41 @@
+#include <Arduino.h>
+#include "HAMQTTHealthCheck.h"
+
+void HAMQTTHealthCheck::begin()
+{
+    // Start the health check task
+    xTaskCreatePinnedToCore(
+        healthCheckTask,
+        "MQTTHealthCheck",
+        4096,
+        this,
+        1,
+        NULL,
+        1 // Core 1
+    );
+}
+
+void HAMQTTHealthCheck::ping()
+{
+    Serial.println("Ping processed");
+    this->lastSavedPing = millis();
+}
+
+void HAMQTTHealthCheck::healthCheckTask(void *param)
+{
+    HAMQTTHealthCheck *self = static_cast<HAMQTTHealthCheck *>(param);
+    while (true)
+    {
+        Serial.println("Healthcheck");
+        if (millis() - self->lastSavedPing > HA_MQTT_HEALTH_CHECK_THRESHOLD)
+        {
+            self->onDisconnected();
+        }
+        delay(HA_MQTT_HEALTH_CHECK_FREQ);
+    }
+}
+
+void HAMQTTHealthCheck::onDisconnected()
+{
+    ESP.restart();
+}

--- a/src/ha_mqtt/HAMQTTHealthCheck.h
+++ b/src/ha_mqtt/HAMQTTHealthCheck.h
@@ -1,0 +1,48 @@
+#ifndef HA_MQTT_HEALTH_CHECK_H
+#define HA_MQTT_HEALTH_CHECK_H
+
+/*
+    How often the health check job should be triggered
+*/
+#define HA_MQTT_HEALTH_CHECK_FREQ 60000 // in millis, 1 minute
+
+/*
+    Threshold after which the system enters disconnected state and the onDisconnected() method is triggered
+*/
+#define HA_MQTT_HEALTH_CHECK_THRESHOLD 60000 * 5 // in millis, 5 minutes
+
+/*
+    The class defines health check processing function.
+    External processes must invoke ping() method to keep the health monitor healthy.
+
+    To start the health check job the begin() method must be invoked. It creates the a task which will be executed
+    every HA_MQTT_HEALTH_CHECK_FREQ milli - healthCheckTask()
+
+    When a dicsonnection occurs - onDisconnected() is triggered
+*/
+class HAMQTTHealthCheck
+{
+private:
+    /* Stores timestamp of the last ping() invocation */
+    long lastSavedPing;
+
+    /*
+        A task that should be executed with defined HA_MQTT_HEALTH_CHECK_FREQ frequency.
+        The goal of the task is to decide whether MQTT can consume messages.
+    */
+    static void healthCheckTask(void *param);
+
+    /* Disonnection handler. The current implementation relies on the ESP.restart() */
+    void onDisconnected();
+
+public:
+    HAMQTTHealthCheck() = default;
+
+    /* Initiates health check task*/
+    void begin();
+
+    /* Must be triggered when the system receives a ping from external system connected via MQTT */
+    void ping();
+};
+
+#endif // HA_MQTT_HEALTH_CHECK_H

--- a/src/ha_mqtt/HAMQTTShutterControl.h
+++ b/src/ha_mqtt/HAMQTTShutterControl.h
@@ -3,6 +3,7 @@
 
 #include "./shutter/HAMQTTShutter.h"
 #include "CosmoMobilusHardwareAdapter.h"
+#include "HAMQTTHealthCheck.h"
 #include "./mqtt_client/MQTTClient.h"
 
 #define FULLY_OPENED 100
@@ -25,6 +26,8 @@ public:
 private:
     MQTTClient &_client;
     CosmoMobilusHardwareAdapter &_hardware;
+
+    HAMQTTHealthCheck *healthCHeck = new HAMQTTHealthCheck();
 
     const char *topic_ha_status = "homeassistant/status";
     const char *topic_ha_control_command = "cosmo-ha-adapter/command";
@@ -50,8 +53,6 @@ private:
     void moveControlForward(uint8_t diff);
     void moveControlBackward(uint8_t diff);
     void close(HAMQTTShutter *shutter);
-
-    void reboot();
 };
 
 #endif // HA_MQTT_SHUTTER_CONTROL_H


### PR DESCRIPTION
…e external system over MQTT.

- THe entire helath check mechanism relies on the ping messages received from Home Assistant (in my case) over MQTT in the dedicated topic
- Refactores the previous attempt of the health check and device reboot.